### PR TITLE
chore(security): harden release pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# CODEOWNERS — release-critical paths
+#
+# Purpose: make the files that can change WHAT GETS PUBLISHED reviewable. Combined
+# with branch protection's "Require review from Code Owners", any change to these
+# paths needs sign-off from the owner below.
+#
+# SPLIT AUTHORITY: the owner is @jaggitadmin — a rarely-used admin identity, kept
+# separate from the day-to-day @jagreehal account and not authenticated on developer
+# workstations. So a compromised day-to-day session cannot approve its own changes
+# to the release pipeline.
+#
+# PREREQUISITES for these rules to take effect:
+#   1. @jaggitadmin is a collaborator on this repo with write access (otherwise
+#      GitHub treats the rule as invalid and silently ignores it).
+#   2. Branch protection / ruleset on `main` has "Require review from Code Owners" on.
+#
+# Per-package (nested) package.json files are intentionally NOT owned here, to avoid
+# blocking routine dependency PRs; the root manifest, lockfile, workspace config,
+# changesets, build/release scripts and all workflows ARE covered.
+
+/.github/workflows/      @jaggitadmin
+/.github/CODEOWNERS      @jaggitadmin
+/package.json            @jaggitadmin
+/pnpm-lock.yaml          @jaggitadmin
+/pnpm-workspace.yaml     @jaggitadmin
+/turbo.json              @jaggitadmin
+/.changeset/             @jaggitadmin
+/scripts/                @jaggitadmin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,26 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'jagreehal'
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: 'pnpm'
@@ -29,7 +37,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
         with:
           version: pnpm version-packages
           publish: pnpm release


### PR DESCRIPTION
Hardens the release pipeline to follow GitHub Actions and npm trusted-publishing security best practices. No functional change to the release flow. Mirrors the reference change reviewed in autotel#200.

## What this changes
- **`environment: release` on the publish job.** Pairs with the npm trusted-publisher **Environment name = `release`** field. A publish can only originate from the protected release path, not an arbitrary branch.
- **Least privilege.** Write scopes moved off the workflow level onto the publish job only; the workflow default is now `contents: read`.
- **Repository-owner guard** — `if: github.repository_owner == 'jagreehal'`.
- **Actions pinned to full commit SHAs** instead of moving tags.
- **`.github/CODEOWNERS`** marks release-critical paths, owned by **`@jaggitadmin`** for required code-owner review.

Triggers only on `push` to `main`, so opening/merging this PR does not publish.

## ⚠️ Required to make these controls bind (web-UI, maintainer)
1. Create the **`release` environment** (Settings → Environments): restrict deployment branches to `main`, add **`@jaggitadmin`** as a **required reviewer**.
2. npm trusted publisher: set **Environment name = `release`**.
3. Add **`@jaggitadmin`** as a collaborator (write) + branch protection → **Require review from Code Owners**.
4. Settings → Actions → default workflow permissions → **read-only**.

> **Note:** this repo still publishes with a long-lived `NPM_TOKEN`. The `environment: release` gate (required reviewer + main-only) now protects that path, but the recommended follow-up is to migrate to **npm trusted publishing (OIDC)** and delete the token entirely. Kept token-based here to avoid breaking publishes before a trusted publisher is configured.
