### PR TITLE
ci(release): OIDC trusted publishing (drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -27,7 +28,11 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npx npm@11 install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -45,5 +50,4 @@ jobs:
           title: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## What
Migrate the release workflow from a long-lived `NPM_TOKEN` to **OIDC trusted publishing** with provenance.

## Why
The original incident involved a harvested npm token. This repo was the last (with autolemetry) still publishing via a long-lived `NPM_TOKEN` secret. OIDC trusted publishing removes that standing credential entirely.

## Changes
- Add job-scoped `id-token: write`
- `setup-node` `registry-url: https://registry.npmjs.org`
- Upgrade npm to 11 (`npx npm@11 install -g npm@11`) for OIDC support
- Publish with provenance (`NPM_CONFIG_PROVENANCE: true`)
- Drop `NPM_TOKEN`/`NODE_AUTH_TOKEN` from the workflow env

## Prereqs (already in place)
- npm trusted publisher bound (`file=release.yml`, `environment=release`)
- `release` environment gate (required reviewer @jaggitadmin, branches main/v*)

## Post-merge
Delete the `NPM_TOKEN` repo secret (no longer referenced).