### PR TITLE
fix: add missing changeset for #488 and restore caret ranges on published deps

### DIFF
--- a/.changeset/eval-sandbox-and-scope-guardrails.md
+++ b/.changeset/eval-sandbox-and-scope-guardrails.md
@@ -1,0 +1,15 @@
+---
+'ai-sdk-guardrails': minor
+---
+
+Add Eval Sandbox, evaluation-scope and tool-egress guardrails, plus stateful plan risk sessions.
+
+- `evaluationScopeGuardrail` — constrains what an evaluation run is allowed to touch, with
+  `EvaluationScopeGuardrailOptions` and `EvaluationScopeMetadata` exported alongside it.
+- `createPlanRiskSession` — carries plan-risk state across turns instead of scoring each plan in
+  isolation, so risk accumulated earlier in a session still counts. Exported with its
+  `PlanRiskSession` type.
+- Tool-call/egress policy now scans tool-call arguments for URLs, catching structured egress that
+  text-only scanning missed.
+
+All additions are new exports; no existing API changed.

--- a/.changeset/unpin-published-dep-ranges.md
+++ b/.changeset/unpin-published-dep-ranges.md
@@ -1,0 +1,10 @@
+---
+'ai-sdk-guardrails': patch
+---
+
+Restore caret ranges on published `dependencies` and `peerDependencies`.
+
+A version-pinning sweep had changed these to exact versions, which would have forced every consumer
+onto exactly `ai@7.0.58` / `autotel-genai@0.4.2` and installed a duplicate `zod` alongside their own —
+duplicate `zod` copies break `instanceof` checks across the boundary. Ranges are carets again, as they
+were before.

--- a/packages/ai-sdk-guardrails/package.json
+++ b/packages/ai-sdk-guardrails/package.json
@@ -78,12 +78,12 @@
     "check-exports": "attw --pack . --ignore-rules false-esm no-resolution"
   },
   "dependencies": {
-    "@ai-sdk/provider": "4.0.7",
-    "zod": "4.4.3"
+    "@ai-sdk/provider": "^4.0.7",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "ai": "7.0.58",
-    "autotel-genai": "0.4.2"
+    "ai": "^7.0.58",
+    "autotel-genai": "^0.4.2"
   },
   "peerDependenciesMeta": {
     "autotel-genai": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,13 +76,13 @@ importers:
   packages/ai-sdk-guardrails:
     dependencies:
       '@ai-sdk/provider':
-        specifier: 4.0.7
+        specifier: ^4.0.7
         version: 4.0.7
       autotel-genai:
-        specifier: 0.4.2
+        specifier: ^0.4.2
         version: 0.4.2(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-logs-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-logs-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-metrics-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-metrics-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1))(yaml@2.9.0)
       zod:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@ai-sdk/groq':
@@ -2215,6 +2215,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -3298,6 +3299,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@17.9.0:


### PR DESCRIPTION
PR #488 merged without a changeset, so the Eval Sandbox work is sitting unreleased on `main`.

## Changeset (minor)

Covers the new public exports from #488:
- `evaluationScopeGuardrail` + `EvaluationScopeGuardrailOptions` / `EvaluationScopeMetadata`
- `createPlanRiskSession` + `PlanRiskSession`
- tool-call/egress policy now scans tool-call args for URLs

Minor, not major — I checked the diff for removed exports. `loadGuardrailBundle`, `inputGuardrailsMiddleware`, `outputGuardrailsMiddleware` and `GuardrailResult` all show as `-export` lines but each is still exported; they were refactored (re-export syntax, `any` → `unknown`), not dropped.

## Also: unpin published dep ranges (patch)

#488's version-pinning sweep caught the published ranges too:

```
"@ai-sdk/provider": "^4.0.3" → "4.0.7"
"zod":              "^4.4.3" → "4.4.3"
"ai":               "^7.0.22" → "7.0.58"   (peer)
"autotel-genai":    "^0.3.2"  → "0.4.2"    (peer)
```

These have been carets for the whole history — `git log -L` on the `peerDependencies` block shows dependabot bumping the caret ranges right up until #488. The sweep commit's message is about TypeScript versions, so this looks incidental rather than intended.

Shipped as-is it would pin consumers to exactly `ai@7.0.58`, and force a duplicate `zod` next to theirs — duplicate `zod` copies break `instanceof` across the boundary. Restored to carets.

Dev dependencies are left pinned; exact pins are fine there.

`changeset status` reports one minor bump. 440 tests pass, `--frozen-lockfile` install clean.