### PR TITLE
fix: support autotel-genai 0.6 peer

### DIFF
--- a/.changeset/widen-autotel-genai-peer.md
+++ b/.changeset/widen-autotel-genai-peer.md
@@ -1,0 +1,5 @@
+---
+"ai-sdk-guardrails": patch
+---
+
+Expand the optional `autotel-genai` peer range to support the published 0.5 and 0.6 releases.

--- a/packages/ai-sdk-guardrails/package.json
+++ b/packages/ai-sdk-guardrails/package.json
@@ -83,7 +83,7 @@
   },
   "peerDependencies": {
     "ai": "^7.0.58",
-    "autotel-genai": "^0.4.2"
+    "autotel-genai": "^0.4.2 || ^0.5.0 || ^0.6.0"
   },
   "peerDependenciesMeta": {
     "autotel-genai": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         specifier: ^4.0.7
         version: 4.0.7
       autotel-genai:
-        specifier: ^0.4.2
+        specifier: ^0.4.2 || ^0.5.0 || ^0.6.0
         version: 0.4.2(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-logs-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-logs-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-metrics-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-metrics-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1))(yaml@2.9.0)
       zod:
         specifier: ^4.4.3


### PR DESCRIPTION
## Summary

- expand the optional `autotel-genai` peer range to include the published 0.5 and 0.6 lines
- update the lockfile peer specifier
- add a patch changeset for `ai-sdk-guardrails`

## Validation

- `pnpm --filter ai-sdk-guardrails format:check`
- `pnpm --filter ai-sdk-guardrails type-check`
- `pnpm --filter ai-sdk-guardrails test` (440 tests)
- `pnpm --filter ai-sdk-guardrails build`
- `pnpm --filter ai-sdk-guardrails check-exports`

Runtime compatibility with `autotel-genai@0.6.0` was also exercised in the agent eval sandbox demo, including guardrail governance, forensic queries, cross-agent detection, and devtools trace ingestion.